### PR TITLE
feat(export): Add createdFrom and createdTo params - Issue #39

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ config.js
 exports
 sftp-credentials.json
 foo
+tmp
+.idea

--- a/.npmignore
+++ b/.npmignore
@@ -12,3 +12,4 @@ create_config.sh
 release-as-zip.sh
 package
 foo
+.idea

--- a/README.md
+++ b/README.md
@@ -19,6 +19,44 @@ $ npm install -g sphere-order-export
 $ order-export
 ```
 
+## General usage
+```$xslt
+Usage: order-export --projectKey key
+
+Options:
+  --projectKey              your SPHERE.IO project-key                                                     [required]
+  --clientId                your OAuth client id for the SPHERE.IO API
+  --clientSecret            your OAuth client secret for the SPHERE.IO API
+  --accessToken             an OAuth access token for the SPHERE.IO API
+  --sphereHost              SPHERE.IO API host to connect to
+  --sphereProtocol          SPHERE.IO API protocol to connect to
+  --sphereAuthHost          SPHERE.IO OAuth host to connect to
+  --sphereAuthProtocol      SPHERE.IO OAuth protocol to connect to
+  --fetchHours              Number of hours to fetch modified orders                                       [default: 48]
+  --createdFrom             UTC datetime from when should orders be fetched                                    
+  --createdTo               UTC datetime until when should orders be fetched                               [default: current timestamp]
+  --perPage                 Number of orders to be fetched per page                                        [default: 100]
+  --standardShippingMethod  Allows to define the fallback shipping method name if order has none           [default: "None"]
+  --exportUnsyncedOnly      whether only unsynced orders will be exported or not                           [default: true]
+  --targetDir               the folder where exported files are saved                                      [default: "/Users/xjunajan/dev/commercetools/sphere-order-export/exports"]
+  --useExportTmpDir         whether to use a system tmp folder to store exported files                     [default: false]
+  --csvTemplate             CSV template to define the structure of the export
+  --createSyncActions       upload syncInfo update actions for orders exported (only supports sftp upload  [default: false]
+  --fileWithTimestamp       whether exported file should contain a timestamp                               [default: false]
+  --sftpCredentials         the path to a JSON file where to read the credentials from
+  --sftpHost                the SFTP host (overwrite value in sftpCredentials JSON, if given)
+  --sftpUsername            the SFTP username (overwrite value in sftpCredentials JSON, if given)
+  --sftpPassword            the SFTP password (overwrite value in sftpCredentials JSON, if given)
+  --sftpTarget              path in the SFTP server to where to move the worked files
+  --sftpContinueOnProblems  ignore errors when processing a file and continue with the next one            [default: false]
+  --logLevel                log level for file logging                                                     [default: "info"]
+  --logDir                  directory to store logs                                                        [default: "."]
+  --logSilent               use console to print messages                                                  [default: false]
+  --timeout                 Set timeout for requests                                                       [default: 60000]
+  --exportCSVAsStream       Exports CSV as stream (to use for performance reasons)                         [default: false]
+```
+
+
 ### SFTP
 Exported orders (XML or CSV) can be automatically uploaded to an SFTP server.
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Options:
   --timeout                 Set timeout for requests                                                       [default: 60000]
   --exportCSVAsStream       Exports CSV as stream (to use for performance reasons)                         [default: false]
 ```
-
+Default value for a `fetchHours` parameter is a time offset of 48 hours. Parameters `createdFrom` or `createdTo` formatted as a UTC date and time in [ISO 8601 format](https://dev.commercetools.com/http-api-types.html#datetime) can help you to export orders in a specified time range.
 
 ### SFTP
 Exported orders (XML or CSV) can be automatically uploaded to an SFTP server.

--- a/src/coffee/orderexport.coffee
+++ b/src/coffee/orderexport.coffee
@@ -16,6 +16,8 @@ class OrderExport
 
   constructor: (options = {}) ->
     @_exportOptions = _.defaults (options.export or {}),
+      createdFrom: null
+      createdTo: null
       fetchHours: 48
       standardShippingMethod: 'None'
       exportType: 'xml'
@@ -61,6 +63,25 @@ class OrderExport
       when 'xml' then @_fetchOrders().then (orders) => @xmlExport(orders)
       else Promise.reject "Undefined export type '#{@_exportOptions.exportType}', supported 'csv' or 'xml'"
 
+  _addDateOffset: (clientService) ->
+    if @_exportOptions.createdTo
+      clientService.where("createdAt <= \"#{@_exportOptions.createdTo}\"")
+
+    if @_exportOptions.createdFrom
+      clientService.where("createdAt >= \"#{@_exportOptions.createdFrom}\"")
+
+    if not @_exportOptions.createdFrom and not @_exportOptions.createdTo
+      clientService.last("#{@_exportOptions.fetchHours}h")
+
+    clientService
+
+  _getClientService: () ->
+    @client.orders
+      .expand('lineItems[*].state[*].state')
+      .expand('lineItems[*].supplyChannel')
+      .expand('discountCodes[*].discountCode')
+      .expand('customerGroup')
+
   runCSVAndStreamToFile: (writeToFile) ->
     @_getCSVOrderTemplate()
     .then (template) => @csvMapping._analyseTemplate(template)
@@ -68,13 +89,11 @@ class OrderExport
       # write first the header
       writeToFile("#{header.join(',')}\n")
       .then () =>
-        @client.orders
-        .expand('lineItems[*].state[*].state')
-        .expand('lineItems[*].supplyChannel')
-        .expand('discountCodes[*].discountCode')
-        .expand('customerGroup')
+        clientService = @_getClientService()
+        clientService = @_addDateOffset(clientService)
+
+        clientService
         .perPage(@_exportOptions.perPage)
-        .last("#{@_exportOptions.fetchHours}h")
         .process (payload) =>
           orders = payload.body.results
           rows = _.map orders, (order) => @csvMapping._mapOrder(order, mappings)
@@ -98,12 +117,10 @@ class OrderExport
       @channel = result.body
 
       # TODO: query also for syncInfo? -> not well supported by the API at the moment
-      @client.orders.all()
-      .expand('lineItems[*].state[*].state')
-      .expand('lineItems[*].supplyChannel')
-      .expand('discountCodes[*].discountCode')
-      .expand('customerGroup')
-      .last("#{@_exportOptions.fetchHours}h")
+      clientService = @_getClientService().all()
+      clientService = @_addDateOffset(clientService)
+
+      clientService
       .fetch()
     .then (result) =>
       allOrders = result.body.results

--- a/src/coffee/run.coffee
+++ b/src/coffee/run.coffee
@@ -21,6 +21,8 @@ argv = require('optimist')
   .describe('sphereAuthHost', 'SPHERE.IO OAuth host to connect to')
   .describe('sphereAuthProtocol', 'SPHERE.IO OAuth protocol to connect to')
   .describe('fetchHours', 'Number of hours to fetch modified orders')
+  .describe('createdFrom', 'UTC datetime from when should orders be fetched')
+  .describe('createdTo', 'UTC datetime until when should orders be fetched')
   .describe('perPage', 'Number of orders to be fetched per page')
   .describe('standardShippingMethod', 'Allows to define the fallback shipping method name if order has none')
   .describe('exportUnsyncedOnly', 'whether only unsynced orders will be exported or not')
@@ -172,6 +174,8 @@ ensureCredentials(argv)
   orderExport = new OrderExport
     client: clientOptions
     export:
+      createdFrom: argv.createdFrom
+      createdTo: argv.createdTo
       fetchHours: argv.fetchHours
       perPage: argv.perPage
       standardShippingMethod: argv.standardShippingMethod

--- a/src/coffee/run.coffee
+++ b/src/coffee/run.coffee
@@ -284,7 +284,7 @@ ensureCredentials(argv)
               .catch (err) ->
                 if argv.sftpContinueOnProblems
                   filesSkipped++
-                  logger.warn err, "There was an error processing the file #{file}, skipping and continue"
+                  logger.warn err, "There was an error processing the file #{filename}, skipping and continue"
                   Promise.resolve()
                 else
                   Promise.reject err

--- a/src/spec/integration/order-export.spec.coffee
+++ b/src/spec/integration/order-export.spec.coffee
@@ -16,7 +16,7 @@ describe 'Integration tests', ->
     @orderExport = new OrderExport client: Config
 
     @orderExport.client.channels.ensure(CHANNEL_KEY, CHANNEL_ROLE)
-    .then (result) =>
+    .then =>
       # get a tax category required for setting up shippingInfo
       #   (simply returning first found)
       @orderExport.client.taxCategories.save SpecHelper.taxCategoryMock()
@@ -42,7 +42,7 @@ describe 'Integration tests', ->
     .then (result) =>
       @order = result.body
       @orderExport.client.customObjects.save SpecHelper.orderPaymentInfo(CONTAINER_PAYMENT, @order.id)
-    .then (result) -> done()
+    .then -> done()
     .catch (err) -> done _.prettify err
   , 20000 # 20sec
 
@@ -73,6 +73,15 @@ describe 'Integration tests', ->
         expect(parsed[1][4]).toBe ''
         done()
     .catch (err) -> done _.prettify err
+  , 10000 #10sec
+
+  it 'should not export CSV into file without template', (done) ->
+    try
+      @orderExport.runCSVAndStreamToFile 'abcd.csv'
+      done 'Should throw an error because of a missing template'
+    catch err
+      expect(err.toString()).toBe 'Error: You need to provide a csv template for exporting order information'
+      done()
   , 10000 #10sec
 
   describe 'elastic.io', ->


### PR DESCRIPTION
This PR adds two new parameters `createdFrom` and `createdTo` which specify time boundaries in order export as requested here in this issue: https://github.com/sphereio/sphere-order-export/issues/39