### PR TITLE
feat(order-export): not generate empty files

### DIFF
--- a/src/coffee/orderexport.coffee
+++ b/src/coffee/orderexport.coffee
@@ -23,6 +23,7 @@ class OrderExport
     @client = new SphereClient options.client
     @xmlMapping = new XmlMapping @_exportOptions
     @csvMapping = new CsvMapping @_exportOptions
+    @ordersExported = false # Flag to avoid empty file being generated if no order is exported
 
   elasticio: (msg, cfg, next, snapshot) ->
     if _.isEmpty msg or _.isEmpty msg.body
@@ -108,8 +109,13 @@ class OrderExport
     .then (result) =>
       allOrders = result.body.results
       if @_exportOptions.exportUnsyncedOnly
-        Promise.resolve @_unsyncedOnly(allOrders, @channel)
+        _unSyncedOrders = @_unsyncedOnly(allOrders, @channel)
+        if _unSyncedOrders.length
+          @ordersExported = true
+        Promise.resolve _unSyncedOrders
       else
+        if allOrders.length
+          @ordersExported = true
         Promise.resolve allOrders
 
   _unsyncedOnly: (orders, channel) ->

--- a/src/coffee/run.coffee
+++ b/src/coffee/run.coffee
@@ -255,6 +255,9 @@ ensureCredentials(argv)
             filesSkipped = 0
             Promise.map files, (filename) =>
               logger.debug "Uploading #{@outputDir}/#{filename}"
+              if not orderExport.ordersExported
+                return Promise.resolve()
+
               sftpClient.safePutFile(sftp, "#{@outputDir}/#{filename}", "#{sftpTarget}/#{filename}")
               .then =>
                 if exportType.toLowerCase() is 'csv' and argv.createSyncActions

--- a/src/spec/orderexport.spec.coffee
+++ b/src/spec/orderexport.spec.coffee
@@ -61,6 +61,24 @@ describe 'OrderExport', ->
     unsyncedOrders = @orderExport._unsyncedOnly(unsyncedOrders(@orderExportChannel.id), @orderExportChannel)
     expect(_.size(unsyncedOrders)).toEqual 2
 
+  it 'should set ordersExported flag to true if orders is returned', (done) ->
+    spyOn(@orderExport.client.orders, 'fetch').andCallFake => Promise.resolve
+      body:
+        results: unsyncedOrders(@orderExport.channel.id)
+    @orderExport._fetchOrders()
+      .then () =>
+        expect(@orderExport.ordersExported).toBeTruthy()
+        done()
+
+  it 'should set ordersExported flag to false if no orders is returned', (done) ->
+    spyOn(@orderExport.client.orders, 'fetch').andCallFake => Promise.resolve
+      body:
+        results: []
+    @orderExport._fetchOrders()
+      .then () =>
+        expect(@orderExport.ordersExported).toBeFalsy()
+        done()
+
   it '#_processXmlOrder', -> # TODO
 
   it '#syncOrder', ->

--- a/src/spec/orderexport.spec.coffee
+++ b/src/spec/orderexport.spec.coffee
@@ -58,8 +58,8 @@ describe 'OrderExport', ->
     .catch (e) -> done e
 
   it '#_unsyncedOnly', ->
-    unsyncedOrders = @orderExport._unsyncedOnly(unsyncedOrders(@orderExportChannel.id), @orderExportChannel)
-    expect(_.size(unsyncedOrders)).toEqual 2
+    _unsyncedOrders = @orderExport._unsyncedOnly(unsyncedOrders(@orderExportChannel.id), @orderExportChannel)
+    expect(_.size(_unsyncedOrders)).toEqual 2
 
   it 'should set ordersExported flag to true if orders is returned', (done) ->
     spyOn(@orderExport.client.orders, 'fetch').andCallFake => Promise.resolve


### PR DESCRIPTION
When no order is exported an empty file is generated.
This commits changes that behaviour, when no order is exported
No file is generated.
This breaking change only applies when the file is being uploaded to sftp.

fixes #43