### PR TITLE
63: Fix discountCode export with deleted codes

### DIFF
--- a/src/coffee/mapping-utils/csv.coffee
+++ b/src/coffee/mapping-utils/csv.coffee
@@ -68,6 +68,10 @@ class CsvMapping
       else [entry]
 
   formatDiscountCodes = (discountCodes) ->
+    discountCodes = _.filter(discountCodes, ({ discountCode }) ->
+      if discountCode.obj
+        return discountCode
+    )
     return _.map(discountCodes, ({ discountCode: { obj: { code } } }) ->
       return code
     ).join(';')


### PR DESCRIPTION
This PR 

- fixes an issue that makes csv orderExport fail when reference resolution to the actual discountCode resource fails because it has been deleted. https://github.com/sphereio/sphere-order-export/commit/035925bed9cea1a30d02eaa761f7cda214b024ff