### PR TITLE
chore(travis-CI): add node v8 to CI and remove v4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
-  - 4
   - 6
+  - 8
 branches:
   except:
     - latest

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "main": "lib/run",
   "engines": {
-    "node": ">= 0.10.0"
+    "node": ">= 6.0.0"
   },
   "scripts": {
     "test": "grunt coverage",


### PR DESCRIPTION
#### Summary
Add node v8 to CI and remove v4

#### Description
Add of node v8 to CI and remove v4 in sphere-stock-import

Part of [this issue](https://github.com/commercetools/nodejs-tasks-board/issues/10)