### PR TITLE
fix(sphere-order-export): Deleted discount codes crashes order export

### DIFF
--- a/data/orders.json
+++ b/data/orders.json
@@ -1,505 +1,712 @@
-[{
-  "id": "abc",
-  "createdAt": "1970-01-01T00:00:00.001Z",
-  "lastModifiedAt": "1970-01-01T00:00:00.002Z",
-  "orderNumber": "10001",
-  "version": 1,
-  "lineItems": [{
-    "id": "LineItemId-1-1",
-    "productId": "ProductId-1-1",
-    "name": {
-      "en": "Product-1-1"
-    },
-    "variant": {
-      "prices": [
-        {
-          "value": {
-            "type": "centPrecision",
-            "currencyCode": "EUR",
-            "centAmount": 12900,
-            "fractionDigits": 2
-          },
-          "id": "5e7734cf-59ca-42d4-bb21-b8c01d0db58d",
-          "country": "DE"
+[
+  {
+    "id": "abc",
+    "createdAt": "1970-01-01T00:00:00.001Z",
+    "lastModifiedAt": "1970-01-01T00:00:00.002Z",
+    "orderNumber": "10001",
+    "version": 1,
+    "lineItems": [
+      {
+        "id": "LineItemId-1-1",
+        "productId": "ProductId-1-1",
+        "name": {
+          "en": "Product-1-1"
         },
-        {
-          "value": {
-            "type": "centPrecision",
-            "currencyCode": "GBP",
-            "centAmount": 11900,
-            "fractionDigits": 2
-          },
-          "id": "51a2bb90-52ae-4e44-9d21-c4583706ddf0",
-          "country": "GB"
-        }
-      ],
-      "variantId": 1,
-      "sku": "SKU-1-1",
-      "images": [{
-        "url": "http://www.example.org/image-1-1-1.jpg",
-        "dimensions": {
-          "w": 0,
-          "h": 0
-        }
-      }, {
-        "url": "http://www.example.org/image-1-1-2.jpg",
-        "dimensions": {
-          "w": 0,
-          "h": 0
-        }
-      }, {
-        "url": "http://www.example.org/image-1-1-3.jpg",
-        "dimensions": {
-          "w": 0,
-          "h": 0
-        }
-      }],
-      "attributes": [
-        {
-          "name": "ltext",
-          "value": {
-            "en": "LtextEN",
-            "de": "LtextDE"
-          }
-        },
-        {
-          "name": "enum",
-          "value": {
-            "key": "EnumKey",
-            "label": "EnumLabel"
-          }
-        },
-        {
-          "name": "text",
-          "value": "StringValue"
-        },
-        {
-          "name": "setOfEnum",
-          "value": [
+        "variant": {
+          "prices": [
             {
-              "key": "key1",
-              "label": "val1"
+              "value": {
+                "type": "centPrecision",
+                "currencyCode": "EUR",
+                "centAmount": 12900,
+                "fractionDigits": 2
+              },
+              "id": "5e7734cf-59ca-42d4-bb21-b8c01d0db58d",
+              "country": "DE"
             },
             {
-              "key": "key2",
-              "label": "val2"
+              "value": {
+                "type": "centPrecision",
+                "currencyCode": "GBP",
+                "centAmount": 11900,
+                "fractionDigits": 2
+              },
+              "id": "51a2bb90-52ae-4e44-9d21-c4583706ddf0",
+              "country": "GB"
             }
-          ]
-        },
-        {
-          "name": "booleanTrue",
-          "value": true
-        },
-        {
-          "name": "booleanFalse",
-          "value": false
-        },
-        {
-          "name": "lenum",
-          "value": {
-            "key": "lenumKey",
-            "label": {
-              "de": "LabelDe",
-              "en": "LabelEn"
-            }
-          }
-        },
-        {
-          "name": "setOfLtext",
-          "value": [
+          ],
+          "variantId": 1,
+          "sku": "SKU-1-1",
+          "images": [
             {
-              "en": "textEn1",
-              "de": "textDe1"
+              "url": "http://www.example.org/image-1-1-1.jpg",
+              "dimensions": {
+                "w": 0,
+                "h": 0
+              }
             },
             {
-              "en": "textEn2",
-              "de": "textDe2"
+              "url": "http://www.example.org/image-1-1-2.jpg",
+              "dimensions": {
+                "w": 0,
+                "h": 0
+              }
+            },
+            {
+              "url": "http://www.example.org/image-1-1-3.jpg",
+              "dimensions": {
+                "w": 0,
+                "h": 0
+              }
             }
-          ]
+          ],
+          "attributes": [
+            {
+              "name": "ltext",
+              "value": {
+                "en": "LtextEN",
+                "de": "LtextDE"
+              }
+            },
+            {
+              "name": "enum",
+              "value": {
+                "key": "EnumKey",
+                "label": "EnumLabel"
+              }
+            },
+            {
+              "name": "text",
+              "value": "StringValue"
+            },
+            {
+              "name": "setOfEnum",
+              "value": [
+                {
+                  "key": "key1",
+                  "label": "val1"
+                },
+                {
+                  "key": "key2",
+                  "label": "val2"
+                }
+              ]
+            },
+            {
+              "name": "booleanTrue",
+              "value": true
+            },
+            {
+              "name": "booleanFalse",
+              "value": false
+            },
+            {
+              "name": "lenum",
+              "value": {
+                "key": "lenumKey",
+                "label": {
+                  "de": "LabelDe",
+                  "en": "LabelEn"
+                }
+              }
+            },
+            {
+              "name": "setOfLtext",
+              "value": [
+                {
+                  "en": "textEn1",
+                  "de": "textDe1"
+                },
+                {
+                  "en": "textEn2",
+                  "de": "textDe2"
+                }
+              ]
+            }
+          ],
+          "availability": {
+            "isOnStock": true,
+            "availableQuantity": 1
+          }
+        },
+        "quantity": 2,
+        "price": {
+          "country": "US",
+          "value": {
+            "currencyCode": "USD",
+            "centAmount": 1190
+          }
+        },
+        "state": [
+          {
+            "quantity": 1,
+            "state": {
+              "typeId": "state",
+              "id": "state-1",
+              "obj": {
+                "key": "firstState"
+              }
+            }
+          },
+          {
+            "quantity": 1,
+            "state": {
+              "typeId": "state",
+              "id": "state-2",
+              "obj": {
+                "key": "secondState"
+              }
+            }
+          }
+        ],
+        "taxRate": {
+          "name": "Standard Tax Rate",
+          "amount": 0.19,
+          "includedInPrice": true,
+          "id": "taxRateId",
+          "country": "US"
         }
-      ],
-      "availability": {
-        "isOnStock": true,
-        "availableQuantity": 1
-      }
-    },
-    "quantity": 2,
-    "price": {
-      "country": "US",
-      "value": {
-        "currencyCode": "USD",
-        "centAmount": 1190
-      }
-    },
-    "state": [{
-      "quantity": 1,
-      "state": {
-        "typeId": "state",
-        "id": "state-1",
-        "obj": {
-          "key": "firstState"
+      },
+      {
+        "id": "LineItemId-1-2",
+        "productId": "ProductId-1-2",
+        "name": {
+          "en": "Product-1-2"
+        },
+        "variant": {
+          "variantId": 2,
+          "sku": "SKU-1-2",
+          "images": [
+            {
+              "url": "http://www.example.org/image-2-1-1.jpg",
+              "dimensions": {
+                "w": 0,
+                "h": 0
+              }
+            },
+            {
+              "url": "http://www.example.org/image-2-1-2.jpg",
+              "dimensions": {
+                "w": 0,
+                "h": 0
+              }
+            },
+            {
+              "url": "http://www.example.org/image-2-1-3.jpg",
+              "dimensions": {
+                "w": 0,
+                "h": 0
+              }
+            }
+          ],
+          "attributes": []
+        },
+        "quantity": 3,
+        "price": {
+          "country": "US",
+          "value": {
+            "currencyCode": "USD",
+            "centAmount": 1190
+          }
+        },
+        "state": [
+          {
+            "quantity": 1,
+            "state": {
+              "typeId": "state",
+              "id": "state-1",
+              "obj": {
+                "key": "firstState"
+              }
+            }
+          },
+          {
+            "quantity": 1,
+            "state": {
+              "typeId": "state",
+              "id": "state-1",
+              "obj": {
+                "key": "secondState"
+              }
+            }
+          },
+          {
+            "quantity": 1,
+            "state": {
+              "typeId": "state",
+              "id": "state-3",
+              "obj": {
+                "key": "thirdState"
+              }
+            }
+          }
+        ],
+        "taxRate": {
+          "name": "Standard Tax Rate",
+          "amount": 0.19,
+          "includedInPrice": true,
+          "id": "taxRateId",
+          "country": "US"
+        },
+        "supplyChannel": {
+          "typeId": "channel",
+          "id": "channel-2",
+          "obj": {
+            "key": "secondChannel"
+          }
         }
       }
-    }, {
-      "quantity": 1,
-      "state": {
-        "typeId": "state",
-        "id": "state-2",
-        "obj": {
-          "key": "secondState"
-        }
-      }
-    }],
-    "taxRate": {
-      "name": "Standard Tax Rate",
-      "amount": 0.19,
-      "includedInPrice": true,
-      "id": "taxRateId",
-      "country": "US"
-    }
-  }, {
-    "id": "LineItemId-1-2",
-    "productId": "ProductId-1-2",
-    "name": {
-      "en": "Product-1-2"
-    },
-    "variant": {
-      "variantId": 2,
-      "sku": "SKU-1-2",
-      "images": [{
-        "url": "http://www.example.org/image-2-1-1.jpg",
-        "dimensions": {
-          "w": 0,
-          "h": 0
-        }
-      }, {
-        "url": "http://www.example.org/image-2-1-2.jpg",
-        "dimensions": {
-          "w": 0,
-          "h": 0
-        }
-      }, {
-        "url": "http://www.example.org/image-2-1-3.jpg",
-        "dimensions": {
-          "w": 0,
-          "h": 0
-        }
-      }],
-      "attributes": []
-    },
-    "quantity": 3,
-    "price": {
-      "country": "US",
-      "value": {
-        "currencyCode": "USD",
-        "centAmount": 1190
-      }
-    },
-    "state": [{
-      "quantity": 1,
-      "state": {
-        "typeId": "state",
-        "id": "state-1",
-        "obj": {
-          "key": "firstState"
-        }
-      }
-    }, {
-      "quantity": 1,
-      "state": {
-        "typeId": "state",
-        "id": "state-1",
-        "obj": {
-          "key": "secondState"
-        }
-      }
-    }, {
-      "quantity": 1,
-      "state": {
-        "typeId": "state",
-        "id": "state-3",
-        "obj": {
-          "key": "thirdState"
-        }
-      }
-    }],
-    "taxRate": {
-      "name": "Standard Tax Rate",
-      "amount": 0.19,
-      "includedInPrice": true,
-      "id": "taxRateId",
-      "country": "US"
-    },
-    "supplyChannel": {
-      "typeId": "channel",
-      "id": "channel-2",
-      "obj": {
-        "key": "secondChannel"
-      }
-    }
-  }],
-  "customLineItems": [],
-  "totalPrice": {
-    "currencyCode": "USD",
-    "centAmount": 5950
-  },
-  "taxedPrice": {
-    "totalNet": {
-      "currencyCode": "USD",
-      "centAmount": 5000
-    },
-    "totalGross": {
+    ],
+    "customLineItems": [],
+    "totalPrice": {
       "currencyCode": "USD",
       "centAmount": 5950
-    },
-    "taxPortions": [{
-      "amount": {
-        "currencyCode": "USD",
-        "centAmount": 950
-      },
-      "rate": 0.19
-    }]
-  },
-  "shippingAddress": {
-    "firstName": "John",
-    "lastName": "Doe",
-    "streetName": "Some Street",
-    "streetNumber": "11",
-    "postalCode": "11111",
-    "city": "Some City",
-    "country": "US"
-  },
-  "billingAddress": {
-    "firstName": "John",
-    "lastName": "Doe",
-    "streetName": "Some Street",
-    "streetNumber": "11",
-    "postalCode": "11111",
-    "city": "Some City",
-    "country": "US"
-  },
-  "shippingInfo": {
-    "price": {
-      "centAmount": 499,
-      "currencyCode": "USD"
-    },
-    "shippingRate": {
-      "price": {
-        "centAmount": 499,
-        "currencyCode": "USD"
-      },
-      "freeAbove": {
-        "centAmount": 20000,
-        "currencyCode": "USD"
-      }
     },
     "taxedPrice": {
       "totalNet": {
         "currencyCode": "USD",
-        "centAmount": 0
+        "centAmount": 5000
       },
       "totalGross": {
         "currencyCode": "USD",
-        "centAmount": 495
-      }
-    },
-    "taxRate": {
-      "name": "Standard Tax Rate",
-      "amount": 0.19,
-      "includedInPrice": true,
-      "id": "taxRateId",
-      "country": "US"
-    },
-    "taxCategory": {
-      "typeId": "tax-category",
-      "id": "taxCategoryId"
-    },
-    "deliveries": [{
-      "id": "delivery-1-1",
-      "createdAt": "1970-01-01T00:00:00.003Z",
-      "items": [{
-        "id": "LineItemId-1-1",
-        "quantity": 1
-      }, {
-        "id": "LineItemId-1-2",
-        "quantity": 1
-      }]
-    }]
-  },
-  "discountCodes": [{
-    "discountCode": {
-      "typeId": "discount-code",
-      "obj": {
-        "code": "code1"
-      }
-    },
-    "state": "MatchesCart"
-  }, {
-    "discountCode": {
-      "typeId": "discount-code",
-      "obj": {
-        "code": "code2"
-      }
-    },
-    "state": "MatchesCart"
-  }],
-  "paymentInfo": {
-    "payments": [
-    { "typeId": "payment", "id": "payment1" },
-    { "typeId": "payment", "id": "payment2" }
-    ]
-  }
-}, {
-  "id": "xyz",
-  "orderNumber": "10002",
-  "createdAt": "1970-01-01T00:00:00.004Z",
-  "lastModifiedAt": "1970-01-01T00:00:00.005Z",
-  "version": 1,
-  "lineItems": [{
-    "id": "LineItemId-2-1",
-    "productId": "ProductId-2-1",
-    "name": {
-      "en": "Product-2-1"
-    },
-    "variant": {
-      "variantId": 1,
-      "sku": "SKU-2-1",
-      "images": [{
-        "url": "http://www.example.org/image-2-1-1.jpg",
-        "dimensions": {
-          "w": 0,
-          "h": 0
-        }
-      }],
-      "attributes": []
-    },
-    "quantity": 1,
-    "price": {
-      "country": "US",
-      "value": {
-        "currencyCode": "USD",
-        "centAmount": 2380
-      }
-    },
-    "state": [{
-      "quantity": 1,
-      "state": {
-        "typeId": "state",
-        "id": "state-1",
-        "obj": {
-          "key": "firstState"
-        }
-      }
-    }],
-    "taxRate": {
-      "name": "Standard Tax Rate",
-      "amount": 0.19,
-      "includedInPrice": true,
-      "id": "taxRateId",
-      "country": "US"
-    },
-    "supplyChannel": {
-      "typeId": "channel",
-      "id": "channel-2",
-      "obj": {
-        "key": "secondChannel"
-      }
-    }
-  }],
-  "customLineItems": [],
-  "totalPrice": {
-    "currencyCode": "USD",
-    "centAmount": 2380
-  },
-  "taxedPrice": {
-    "totalNet": {
-      "currencyCode": "USD",
-      "centAmount": 2000
-    },
-    "totalGross": {
-      "currencyCode": "USD",
-      "centAmount": 2380
-    },
-    "taxPortions": [{
-      "amount": {
-        "currencyCode": "USD",
-        "centAmount": 380
+        "centAmount": 5950
       },
-      "rate": 0.19
-    }]
-  },
-  "customerGroup": {
-    "typeId": "customer-group",
-    "id": "customer-group-2",
-    "obj": {
-      "name": "cool customers"
-    }
-  },
-  "shippingAddress": {
-    "firstName": "Jane",
-    "lastName": "Doe",
-    "streetName": "Some Other Street ",
-    "streetNumber": "22",
-    "postalCode": "22222",
-    "city": "Some Other City",
-    "country": "US"
-  },
-  "billingAddress": {
-    "firstName": "Jane",
-    "lastName": "Doe",
-    "streetName": "Some Other Street ",
-    "streetNumber": "22",
-    "postalCode": "22222",
-    "city": "Some Other City",
-    "country": "US"
-  },
-  "shippingInfo": {
-    "price": {
-      "centAmount": 499,
-      "currencyCode": "USD"
+      "taxPortions": [
+        {
+          "amount": {
+            "currencyCode": "USD",
+            "centAmount": 950
+          },
+          "rate": 0.19
+        }
+      ]
     },
-    "shippingRate": {
+    "shippingAddress": {
+      "firstName": "John",
+      "lastName": "Doe",
+      "streetName": "Some Street",
+      "streetNumber": "11",
+      "postalCode": "11111",
+      "city": "Some City",
+      "country": "US"
+    },
+    "billingAddress": {
+      "firstName": "John",
+      "lastName": "Doe",
+      "streetName": "Some Street",
+      "streetNumber": "11",
+      "postalCode": "11111",
+      "city": "Some City",
+      "country": "US"
+    },
+    "shippingInfo": {
       "price": {
         "centAmount": 499,
         "currencyCode": "USD"
       },
-      "freeAbove": {
-        "centAmount": 20000,
-        "currencyCode": "USD"
+      "shippingRate": {
+        "price": {
+          "centAmount": 499,
+          "currencyCode": "USD"
+        },
+        "freeAbove": {
+          "centAmount": 20000,
+          "currencyCode": "USD"
+        }
+      },
+      "taxedPrice": {
+        "totalNet": {
+          "currencyCode": "USD",
+          "centAmount": 0
+        },
+        "totalGross": {
+          "currencyCode": "USD",
+          "centAmount": 495
+        }
+      },
+      "taxRate": {
+        "name": "Standard Tax Rate",
+        "amount": 0.19,
+        "includedInPrice": true,
+        "id": "taxRateId",
+        "country": "US"
+      },
+      "taxCategory": {
+        "typeId": "tax-category",
+        "id": "taxCategoryId"
+      },
+      "deliveries": [
+        {
+          "id": "delivery-1-1",
+          "createdAt": "1970-01-01T00:00:00.003Z",
+          "items": [
+            {
+              "id": "LineItemId-1-1",
+              "quantity": 1
+            },
+            {
+              "id": "LineItemId-1-2",
+              "quantity": 1
+            }
+          ]
+        }
+      ]
+    },
+    "discountCodes": [
+      {
+        "discountCode": {
+          "typeId": "discount-code",
+          "obj": {
+            "code": "code1"
+          }
+        },
+        "state": "MatchesCart"
+      },
+      {
+        "discountCode": {
+          "typeId": "discount-code",
+          "obj": {
+            "code": "code2"
+          }
+        },
+        "state": "MatchesCart"
+      }
+    ],
+    "paymentInfo": {
+      "payments": [
+        { "typeId": "payment", "id": "payment1" },
+        { "typeId": "payment", "id": "payment2" }
+      ]
+    }
+  },
+  {
+    "id": "xyz",
+    "orderNumber": "10002",
+    "createdAt": "1970-01-01T00:00:00.004Z",
+    "lastModifiedAt": "1970-01-01T00:00:00.005Z",
+    "version": 1,
+    "lineItems": [
+      {
+        "id": "LineItemId-2-1",
+        "productId": "ProductId-2-1",
+        "name": {
+          "en": "Product-2-1"
+        },
+        "variant": {
+          "variantId": 1,
+          "sku": "SKU-2-1",
+          "images": [
+            {
+              "url": "http://www.example.org/image-2-1-1.jpg",
+              "dimensions": {
+                "w": 0,
+                "h": 0
+              }
+            }
+          ],
+          "attributes": []
+        },
+        "quantity": 1,
+        "price": {
+          "country": "US",
+          "value": {
+            "currencyCode": "USD",
+            "centAmount": 2380
+          }
+        },
+        "state": [
+          {
+            "quantity": 1,
+            "state": {
+              "typeId": "state",
+              "id": "state-1",
+              "obj": {
+                "key": "firstState"
+              }
+            }
+          }
+        ],
+        "taxRate": {
+          "name": "Standard Tax Rate",
+          "amount": 0.19,
+          "includedInPrice": true,
+          "id": "taxRateId",
+          "country": "US"
+        },
+        "supplyChannel": {
+          "typeId": "channel",
+          "id": "channel-2",
+          "obj": {
+            "key": "secondChannel"
+          }
+        }
+      }
+    ],
+    "customLineItems": [],
+    "totalPrice": {
+      "currencyCode": "USD",
+      "centAmount": 2380
+    },
+    "taxedPrice": {
+      "totalNet": {
+        "currencyCode": "USD",
+        "centAmount": 2000
+      },
+      "totalGross": {
+        "currencyCode": "USD",
+        "centAmount": 2380
+      },
+      "taxPortions": [
+        {
+          "amount": {
+            "currencyCode": "USD",
+            "centAmount": 380
+          },
+          "rate": 0.19
+        }
+      ]
+    },
+    "customerGroup": {
+      "typeId": "customer-group",
+      "id": "customer-group-2",
+      "obj": {
+        "name": "cool customers"
       }
     },
-    "taxRate": {
-      "name": "Standard Tax Rate",
-      "amount": 0.19,
-      "includedInPrice": true,
-      "id": "taxRateId",
+    "shippingAddress": {
+      "firstName": "Jane",
+      "lastName": "Doe",
+      "streetName": "Some Other Street ",
+      "streetNumber": "22",
+      "postalCode": "22222",
+      "city": "Some Other City",
       "country": "US"
     },
-    "taxCategory": {
-      "typeId": "tax-category",
-      "id": "taxCategoryId"
+    "billingAddress": {
+      "firstName": "Jane",
+      "lastName": "Doe",
+      "streetName": "Some Other Street ",
+      "streetNumber": "22",
+      "postalCode": "22222",
+      "city": "Some Other City",
+      "country": "US"
     },
-    "deliveries": [{
-      "id": "deliveryId-2-1",
-      "createdAt": "1970-01-01T00:00:00.006Z",
-      "items": [{
-        "id": "LineItemId-2-1",
-        "quantity": 1
-      }]
-    }]
+    "shippingInfo": {
+      "price": {
+        "centAmount": 499,
+        "currencyCode": "USD"
+      },
+      "shippingRate": {
+        "price": {
+          "centAmount": 499,
+          "currencyCode": "USD"
+        },
+        "freeAbove": {
+          "centAmount": 20000,
+          "currencyCode": "USD"
+        }
+      },
+      "taxRate": {
+        "name": "Standard Tax Rate",
+        "amount": 0.19,
+        "includedInPrice": true,
+        "id": "taxRateId",
+        "country": "US"
+      },
+      "taxCategory": {
+        "typeId": "tax-category",
+        "id": "taxCategoryId"
+      },
+      "deliveries": [
+        {
+          "id": "deliveryId-2-1",
+          "createdAt": "1970-01-01T00:00:00.006Z",
+          "items": [
+            {
+              "id": "LineItemId-2-1",
+              "quantity": 1
+            }
+          ]
+        }
+      ]
+    },
+    "discountCodes": [
+      {
+        "discountCode": {
+          "typeId": "discount-code",
+          "obj": {
+            "code": "code3"
+          }
+        },
+        "state": "MatchesCart"
+      }
+    ],
+    "paymentInfo": {
+      "payments": [{ "typeId": "payment", "id": "payment3" }]
+    }
   },
-  "discountCodes": [{
-    "discountCode": {
-      "typeId": "discount-code",
-        "obj": {
-        "code": "code3"
+  {
+    "id": "ijk",
+    "orderNumber": "10003",
+    "createdAt": "1970-01-01T00:00:00.004Z",
+    "lastModifiedAt": "1970-01-01T00:00:00.005Z",
+    "version": 1,
+    "lineItems": [
+      {
+        "id": "LineItemId-3-1",
+        "productId": "ProductId-3-1",
+        "name": {
+          "en": "Product-3-1"
+        },
+        "variant": {
+          "variantId": 1,
+          "sku": "SKU-3-1",
+          "images": [
+            {
+              "url": "http://www.example.org/image-3-1-1.jpg",
+              "dimensions": {
+                "w": 0,
+                "h": 0
+              }
+            }
+          ],
+          "attributes": []
+        },
+        "quantity": 1,
+        "price": {
+          "country": "DE",
+          "value": {
+            "currencyCode": "EUR",
+            "centAmount": 3000
+          }
+        },
+        "state": [
+          {
+            "quantity": 1,
+            "state": {
+              "typeId": "state",
+              "id": "state-1",
+              "obj": {
+                "key": "firstState"
+              }
+            }
+          }
+        ],
+        "taxRate": {
+          "name": "Standard Tax Rate",
+          "amount": 0.25,
+          "includedInPrice": true,
+          "id": "taxRateId",
+          "country": "DE"
+        },
+        "supplyChannel": {
+          "typeId": "channel",
+          "id": "channel-3",
+          "obj": {
+            "key": "thirdChannel"
+          }
+        }
+      }
+    ],
+    "customLineItems": [],
+    "totalPrice": {
+      "currencyCode": "EUR",
+      "centAmount": 3000
+    },
+    "taxedPrice": {
+      "totalNet": {
+        "currencyCode": "EUR",
+        "centAmount": 2250
+      },
+      "totalGross": {
+        "currencyCode": "EUR",
+        "centAmount": 3000
+      },
+      "taxPortions": [
+        {
+          "amount": {
+            "currencyCode": "EUR",
+            "centAmount": 750
+          },
+          "rate": 0.25
+        }
+      ]
+    },
+    "customerGroup": {
+      "typeId": "customer-group",
+      "id": "customer-group-3",
+      "obj": {
+        "name": "tech customers"
       }
     },
-    "state": "MatchesCart"
-  }],
-  "paymentInfo": {
-    "payments": [
-    { "typeId": "payment", "id": "payment3" }
-    ]
+    "shippingAddress": {
+      "firstName": "John",
+      "lastName": "Bull",
+      "streetName": "One Way Street",
+      "streetNumber": "3",
+      "postalCode": "3333",
+      "city": "Star City",
+      "country": "DE"
+    },
+    "billingAddress": {
+      "firstName": "John",
+      "lastName": "Bull",
+      "streetName": "One Way Street",
+      "streetNumber": "3",
+      "postalCode": "3333",
+      "city": "Star City",
+      "country": "DE"
+    },
+    "shippingInfo": {
+      "price": {
+        "centAmount": 500,
+        "currencyCode": "EUR"
+      },
+      "shippingRate": {
+        "price": {
+          "centAmount": 500,
+          "currencyCode": "EUR"
+        },
+        "freeAbove": {
+          "centAmount": 20000,
+          "currencyCode": "EUR"
+        }
+      },
+      "taxRate": {
+        "name": "Standard Tax Rate",
+        "amount": 0.25,
+        "includedInPrice": true,
+        "id": "taxRateId",
+        "country": "DE"
+      },
+      "taxCategory": {
+        "typeId": "tax-category",
+        "id": "taxCategoryId"
+      },
+      "deliveries": [
+        {
+          "id": "deliveryId-3-1",
+          "createdAt": "1970-01-01T00:00:00.006Z",
+          "items": [
+            {
+              "id": "LineItemId-3-1",
+              "quantity": 1
+            }
+          ]
+        }
+      ]
+    },
+    "discountCodes": [
+      {
+        "discountCode": {
+          "typeId": "discount-code",
+          "obj": {}
+        },
+        "state": "MatchesCart"
+      }
+    ],
+    "paymentInfo": {
+      "payments": [{ "typeId": "payment", "id": "payment4" }]
+    }
   }
-}]
+]

--- a/data/orders.json
+++ b/data/orders.json
@@ -1,711 +1,655 @@
-[
-  {
-    "id": "abc",
-    "createdAt": "1970-01-01T00:00:00.001Z",
-    "lastModifiedAt": "1970-01-01T00:00:00.002Z",
-    "orderNumber": "10001",
-    "version": 1,
-    "lineItems": [
-      {
-        "id": "LineItemId-1-1",
-        "productId": "ProductId-1-1",
-        "name": {
-          "en": "Product-1-1"
-        },
-        "variant": {
-          "prices": [
-            {
-              "value": {
-                "type": "centPrecision",
-                "currencyCode": "EUR",
-                "centAmount": 12900,
-                "fractionDigits": 2
-              },
-              "id": "5e7734cf-59ca-42d4-bb21-b8c01d0db58d",
-              "country": "DE"
-            },
-            {
-              "value": {
-                "type": "centPrecision",
-                "currencyCode": "GBP",
-                "centAmount": 11900,
-                "fractionDigits": 2
-              },
-              "id": "51a2bb90-52ae-4e44-9d21-c4583706ddf0",
-              "country": "GB"
-            }
-          ],
-          "variantId": 1,
-          "sku": "SKU-1-1",
-          "images": [
-            {
-              "url": "http://www.example.org/image-1-1-1.jpg",
-              "dimensions": {
-                "w": 0,
-                "h": 0
-              }
-            },
-            {
-              "url": "http://www.example.org/image-1-1-2.jpg",
-              "dimensions": {
-                "w": 0,
-                "h": 0
-              }
-            },
-            {
-              "url": "http://www.example.org/image-1-1-3.jpg",
-              "dimensions": {
-                "w": 0,
-                "h": 0
-              }
-            }
-          ],
-          "attributes": [
-            {
-              "name": "ltext",
-              "value": {
-                "en": "LtextEN",
-                "de": "LtextDE"
-              }
-            },
-            {
-              "name": "enum",
-              "value": {
-                "key": "EnumKey",
-                "label": "EnumLabel"
-              }
-            },
-            {
-              "name": "text",
-              "value": "StringValue"
-            },
-            {
-              "name": "setOfEnum",
-              "value": [
-                {
-                  "key": "key1",
-                  "label": "val1"
-                },
-                {
-                  "key": "key2",
-                  "label": "val2"
-                }
-              ]
-            },
-            {
-              "name": "booleanTrue",
-              "value": true
-            },
-            {
-              "name": "booleanFalse",
-              "value": false
-            },
-            {
-              "name": "lenum",
-              "value": {
-                "key": "lenumKey",
-                "label": {
-                  "de": "LabelDe",
-                  "en": "LabelEn"
-                }
-              }
-            },
-            {
-              "name": "setOfLtext",
-              "value": [
-                {
-                  "en": "textEn1",
-                  "de": "textDe1"
-                },
-                {
-                  "en": "textEn2",
-                  "de": "textDe2"
-                }
-              ]
-            }
-          ],
-          "availability": {
-            "isOnStock": true,
-            "availableQuantity": 1
-          }
-        },
-        "quantity": 2,
-        "price": {
-          "country": "US",
+[{
+  "id": "abc",
+  "createdAt": "1970-01-01T00:00:00.001Z",
+  "lastModifiedAt": "1970-01-01T00:00:00.002Z",
+  "orderNumber": "10001",
+  "version": 1,
+  "lineItems": [{
+    "id": "LineItemId-1-1",
+    "productId": "ProductId-1-1",
+    "name": {
+      "en": "Product-1-1"
+    },
+    "variant": {
+      "prices": [
+        {
           "value": {
-            "currencyCode": "USD",
-            "centAmount": 1190
-          }
-        },
-        "state": [
-          {
-            "quantity": 1,
-            "state": {
-              "typeId": "state",
-              "id": "state-1",
-              "obj": {
-                "key": "firstState"
-              }
-            }
+            "type": "centPrecision",
+            "currencyCode": "EUR",
+            "centAmount": 12900,
+            "fractionDigits": 2
           },
-          {
-            "quantity": 1,
-            "state": {
-              "typeId": "state",
-              "id": "state-2",
-              "obj": {
-                "key": "secondState"
-              }
-            }
-          }
-        ],
-        "taxRate": {
-          "name": "Standard Tax Rate",
-          "amount": 0.19,
-          "includedInPrice": true,
-          "id": "taxRateId",
-          "country": "US"
+          "id": "5e7734cf-59ca-42d4-bb21-b8c01d0db58d",
+          "country": "DE"
+        },
+        {
+          "value": {
+            "type": "centPrecision",
+            "currencyCode": "GBP",
+            "centAmount": 11900,
+            "fractionDigits": 2
+          },
+          "id": "51a2bb90-52ae-4e44-9d21-c4583706ddf0",
+          "country": "GB"
         }
-      },
-      {
-        "id": "LineItemId-1-2",
-        "productId": "ProductId-1-2",
-        "name": {
-          "en": "Product-1-2"
-        },
-        "variant": {
-          "variantId": 2,
-          "sku": "SKU-1-2",
-          "images": [
-            {
-              "url": "http://www.example.org/image-2-1-1.jpg",
-              "dimensions": {
-                "w": 0,
-                "h": 0
-              }
-            },
-            {
-              "url": "http://www.example.org/image-2-1-2.jpg",
-              "dimensions": {
-                "w": 0,
-                "h": 0
-              }
-            },
-            {
-              "url": "http://www.example.org/image-2-1-3.jpg",
-              "dimensions": {
-                "w": 0,
-                "h": 0
-              }
-            }
-          ],
-          "attributes": []
-        },
-        "quantity": 3,
-        "price": {
-          "country": "US",
+      ],
+      "variantId": 1,
+      "sku": "SKU-1-1",
+      "images": [{
+        "url": "http://www.example.org/image-1-1-1.jpg",
+        "dimensions": {
+          "w": 0,
+          "h": 0
+        }
+      }, {
+        "url": "http://www.example.org/image-1-1-2.jpg",
+        "dimensions": {
+          "w": 0,
+          "h": 0
+        }
+      }, {
+        "url": "http://www.example.org/image-1-1-3.jpg",
+        "dimensions": {
+          "w": 0,
+          "h": 0
+        }
+      }],
+      "attributes": [
+        {
+          "name": "ltext",
           "value": {
-            "currencyCode": "USD",
-            "centAmount": 1190
+            "en": "LtextEN",
+            "de": "LtextDE"
           }
         },
-        "state": [
-          {
-            "quantity": 1,
-            "state": {
-              "typeId": "state",
-              "id": "state-1",
-              "obj": {
-                "key": "firstState"
-              }
-            }
-          },
-          {
-            "quantity": 1,
-            "state": {
-              "typeId": "state",
-              "id": "state-1",
-              "obj": {
-                "key": "secondState"
-              }
-            }
-          },
-          {
-            "quantity": 1,
-            "state": {
-              "typeId": "state",
-              "id": "state-3",
-              "obj": {
-                "key": "thirdState"
-              }
-            }
+        {
+          "name": "enum",
+          "value": {
+            "key": "EnumKey",
+            "label": "EnumLabel"
           }
-        ],
-        "taxRate": {
-          "name": "Standard Tax Rate",
-          "amount": 0.19,
-          "includedInPrice": true,
-          "id": "taxRateId",
-          "country": "US"
         },
-        "supplyChannel": {
-          "typeId": "channel",
-          "id": "channel-2",
-          "obj": {
-            "key": "secondChannel"
+        {
+          "name": "text",
+          "value": "StringValue"
+        },
+        {
+          "name": "setOfEnum",
+          "value": [
+            {
+              "key": "key1",
+              "label": "val1"
+            },
+            {
+              "key": "key2",
+              "label": "val2"
+            }
+          ]
+        },
+        {
+          "name": "booleanTrue",
+          "value": true
+        },
+        {
+          "name": "booleanFalse",
+          "value": false
+        },
+        {
+          "name": "lenum",
+          "value": {
+            "key": "lenumKey",
+            "label": {
+              "de": "LabelDe",
+              "en": "LabelEn"
+            }
           }
+        },
+        {
+          "name": "setOfLtext",
+          "value": [
+            {
+              "en": "textEn1",
+              "de": "textDe1"
+            },
+            {
+              "en": "textEn2",
+              "de": "textDe2"
+            }
+          ]
+        }
+      ],
+      "availability": {
+        "isOnStock": true,
+        "availableQuantity": 1
+      }
+    },
+    "quantity": 2,
+    "price": {
+      "country": "US",
+      "value": {
+        "currencyCode": "USD",
+        "centAmount": 1190
+      }
+    },
+    "state": [{
+      "quantity": 1,
+      "state": {
+        "typeId": "state",
+        "id": "state-1",
+        "obj": {
+          "key": "firstState"
         }
       }
-    ],
-    "customLineItems": [],
-    "totalPrice": {
+    }, {
+      "quantity": 1,
+      "state": {
+        "typeId": "state",
+        "id": "state-2",
+        "obj": {
+          "key": "secondState"
+        }
+      }
+    }],
+    "taxRate": {
+      "name": "Standard Tax Rate",
+      "amount": 0.19,
+      "includedInPrice": true,
+      "id": "taxRateId",
+      "country": "US"
+    }
+  }, {
+    "id": "LineItemId-1-2",
+    "productId": "ProductId-1-2",
+    "name": {
+      "en": "Product-1-2"
+    },
+    "variant": {
+      "variantId": 2,
+      "sku": "SKU-1-2",
+      "images": [{
+        "url": "http://www.example.org/image-2-1-1.jpg",
+        "dimensions": {
+          "w": 0,
+          "h": 0
+        }
+      }, {
+        "url": "http://www.example.org/image-2-1-2.jpg",
+        "dimensions": {
+          "w": 0,
+          "h": 0
+        }
+      }, {
+        "url": "http://www.example.org/image-2-1-3.jpg",
+        "dimensions": {
+          "w": 0,
+          "h": 0
+        }
+      }],
+      "attributes": []
+    },
+    "quantity": 3,
+    "price": {
+      "country": "US",
+      "value": {
+        "currencyCode": "USD",
+        "centAmount": 1190
+      }
+    },
+    "state": [{
+      "quantity": 1,
+      "state": {
+        "typeId": "state",
+        "id": "state-1",
+        "obj": {
+          "key": "firstState"
+        }
+      }
+    }, {
+      "quantity": 1,
+      "state": {
+        "typeId": "state",
+        "id": "state-1",
+        "obj": {
+          "key": "secondState"
+        }
+      }
+    }, {
+      "quantity": 1,
+      "state": {
+        "typeId": "state",
+        "id": "state-3",
+        "obj": {
+          "key": "thirdState"
+        }
+      }
+    }],
+    "taxRate": {
+      "name": "Standard Tax Rate",
+      "amount": 0.19,
+      "includedInPrice": true,
+      "id": "taxRateId",
+      "country": "US"
+    },
+    "supplyChannel": {
+      "typeId": "channel",
+      "id": "channel-2",
+      "obj": {
+        "key": "secondChannel"
+      }
+    }
+  }],
+  "customLineItems": [],
+  "totalPrice": {
+    "currencyCode": "USD",
+    "centAmount": 5950
+  },
+  "taxedPrice": {
+    "totalNet": {
+      "currencyCode": "USD",
+      "centAmount": 5000
+    },
+    "totalGross": {
       "currencyCode": "USD",
       "centAmount": 5950
     },
-    "taxedPrice": {
-      "totalNet": {
+    "taxPortions": [{
+      "amount": {
         "currencyCode": "USD",
-        "centAmount": 5000
+        "centAmount": 950
       },
-      "totalGross": {
-        "currencyCode": "USD",
-        "centAmount": 5950
-      },
-      "taxPortions": [
-        {
-          "amount": {
-            "currencyCode": "USD",
-            "centAmount": 950
-          },
-          "rate": 0.19
-        }
-      ]
+      "rate": 0.19
+    }]
+  },
+  "shippingAddress": {
+    "firstName": "John",
+    "lastName": "Doe",
+    "streetName": "Some Street",
+    "streetNumber": "11",
+    "postalCode": "11111",
+    "city": "Some City",
+    "country": "US"
+  },
+  "billingAddress": {
+    "firstName": "John",
+    "lastName": "Doe",
+    "streetName": "Some Street",
+    "streetNumber": "11",
+    "postalCode": "11111",
+    "city": "Some City",
+    "country": "US"
+  },
+  "shippingInfo": {
+    "price": {
+      "centAmount": 499,
+      "currencyCode": "USD"
     },
-    "shippingAddress": {
-      "firstName": "John",
-      "lastName": "Doe",
-      "streetName": "Some Street",
-      "streetNumber": "11",
-      "postalCode": "11111",
-      "city": "Some City",
-      "country": "US"
-    },
-    "billingAddress": {
-      "firstName": "John",
-      "lastName": "Doe",
-      "streetName": "Some Street",
-      "streetNumber": "11",
-      "postalCode": "11111",
-      "city": "Some City",
-      "country": "US"
-    },
-    "shippingInfo": {
+    "shippingRate": {
       "price": {
         "centAmount": 499,
         "currencyCode": "USD"
       },
-      "shippingRate": {
-        "price": {
-          "centAmount": 499,
-          "currencyCode": "USD"
-        },
-        "freeAbove": {
-          "centAmount": 20000,
-          "currencyCode": "USD"
-        }
-      },
-      "taxedPrice": {
-        "totalNet": {
-          "currencyCode": "USD",
-          "centAmount": 0
-        },
-        "totalGross": {
-          "currencyCode": "USD",
-          "centAmount": 495
-        }
-      },
-      "taxRate": {
-        "name": "Standard Tax Rate",
-        "amount": 0.19,
-        "includedInPrice": true,
-        "id": "taxRateId",
-        "country": "US"
-      },
-      "taxCategory": {
-        "typeId": "tax-category",
-        "id": "taxCategoryId"
-      },
-      "deliveries": [
-        {
-          "id": "delivery-1-1",
-          "createdAt": "1970-01-01T00:00:00.003Z",
-          "items": [
-            {
-              "id": "LineItemId-1-1",
-              "quantity": 1
-            },
-            {
-              "id": "LineItemId-1-2",
-              "quantity": 1
-            }
-          ]
-        }
-      ]
+      "freeAbove": {
+        "centAmount": 20000,
+        "currencyCode": "USD"
+      }
     },
-    "discountCodes": [
-      {
-        "discountCode": {
-          "typeId": "discount-code",
-          "obj": {
-            "code": "code1"
-          }
-        },
-        "state": "MatchesCart"
+    "taxedPrice": {
+      "totalNet": {
+        "currencyCode": "USD",
+        "centAmount": 0
       },
-      {
-        "discountCode": {
-          "typeId": "discount-code",
-          "obj": {
-            "code": "code2"
-          }
-        },
-        "state": "MatchesCart"
+      "totalGross": {
+        "currencyCode": "USD",
+        "centAmount": 495
       }
-    ],
-    "paymentInfo": {
-      "payments": [
-        { "typeId": "payment", "id": "payment1" },
-        { "typeId": "payment", "id": "payment2" }
-      ]
-    }
+    },
+    "taxRate": {
+      "name": "Standard Tax Rate",
+      "amount": 0.19,
+      "includedInPrice": true,
+      "id": "taxRateId",
+      "country": "US"
+    },
+    "taxCategory": {
+      "typeId": "tax-category",
+      "id": "taxCategoryId"
+    },
+    "deliveries": [{
+      "id": "delivery-1-1",
+      "createdAt": "1970-01-01T00:00:00.003Z",
+      "items": [{
+        "id": "LineItemId-1-1",
+        "quantity": 1
+      }, {
+        "id": "LineItemId-1-2",
+        "quantity": 1
+      }]
+    }]
   },
-  {
-    "id": "xyz",
-    "orderNumber": "10002",
-    "createdAt": "1970-01-01T00:00:00.004Z",
-    "lastModifiedAt": "1970-01-01T00:00:00.005Z",
-    "version": 1,
-    "lineItems": [
-      {
-        "id": "LineItemId-2-1",
-        "productId": "ProductId-2-1",
-        "name": {
-          "en": "Product-2-1"
-        },
-        "variant": {
-          "variantId": 1,
-          "sku": "SKU-2-1",
-          "images": [
-            {
-              "url": "http://www.example.org/image-2-1-1.jpg",
-              "dimensions": {
-                "w": 0,
-                "h": 0
-              }
-            }
-          ],
-          "attributes": []
-        },
-        "quantity": 1,
-        "price": {
-          "country": "US",
-          "value": {
-            "currencyCode": "USD",
-            "centAmount": 2380
-          }
-        },
-        "state": [
-          {
-            "quantity": 1,
-            "state": {
-              "typeId": "state",
-              "id": "state-1",
-              "obj": {
-                "key": "firstState"
-              }
-            }
-          }
-        ],
-        "taxRate": {
-          "name": "Standard Tax Rate",
-          "amount": 0.19,
-          "includedInPrice": true,
-          "id": "taxRateId",
-          "country": "US"
-        },
-        "supplyChannel": {
-          "typeId": "channel",
-          "id": "channel-2",
-          "obj": {
-            "key": "secondChannel"
-          }
+  "discountCodes": [{
+    "discountCode": {
+      "typeId": "discount-code",
+      "obj": {
+        "code": "code1"
+      }
+    },
+    "state": "MatchesCart"
+  }, {
+    "discountCode": {
+      "typeId": "discount-code",
+      "obj": {
+        "code": "code2"
+      }
+    },
+    "state": "MatchesCart"
+  }],
+  "paymentInfo": {
+    "payments": [
+    { "typeId": "payment", "id": "payment1" },
+    { "typeId": "payment", "id": "payment2" }
+    ]
+  }
+}, {
+  "id": "xyz",
+  "orderNumber": "10002",
+  "createdAt": "1970-01-01T00:00:00.004Z",
+  "lastModifiedAt": "1970-01-01T00:00:00.005Z",
+  "version": 1,
+  "lineItems": [{
+    "id": "LineItemId-2-1",
+    "productId": "ProductId-2-1",
+    "name": {
+      "en": "Product-2-1"
+    },
+    "variant": {
+      "variantId": 1,
+      "sku": "SKU-2-1",
+      "images": [{
+        "url": "http://www.example.org/image-2-1-1.jpg",
+        "dimensions": {
+          "w": 0,
+          "h": 0
+        }
+      }],
+      "attributes": []
+    },
+    "quantity": 1,
+    "price": {
+      "country": "US",
+      "value": {
+        "currencyCode": "USD",
+        "centAmount": 2380
+      }
+    },
+    "state": [{
+      "quantity": 1,
+      "state": {
+        "typeId": "state",
+        "id": "state-1",
+        "obj": {
+          "key": "firstState"
         }
       }
-    ],
-    "customLineItems": [],
-    "totalPrice": {
+    }],
+    "taxRate": {
+      "name": "Standard Tax Rate",
+      "amount": 0.19,
+      "includedInPrice": true,
+      "id": "taxRateId",
+      "country": "US"
+    },
+    "supplyChannel": {
+      "typeId": "channel",
+      "id": "channel-2",
+      "obj": {
+        "key": "secondChannel"
+      }
+    }
+  }],
+  "customLineItems": [],
+  "totalPrice": {
+    "currencyCode": "USD",
+    "centAmount": 2380
+  },
+  "taxedPrice": {
+    "totalNet": {
+      "currencyCode": "USD",
+      "centAmount": 2000
+    },
+    "totalGross": {
       "currencyCode": "USD",
       "centAmount": 2380
     },
-    "taxedPrice": {
-      "totalNet": {
+    "taxPortions": [{
+      "amount": {
         "currencyCode": "USD",
-        "centAmount": 2000
+        "centAmount": 380
       },
-      "totalGross": {
-        "currencyCode": "USD",
-        "centAmount": 2380
-      },
-      "taxPortions": [
-        {
-          "amount": {
-            "currencyCode": "USD",
-            "centAmount": 380
-          },
-          "rate": 0.19
-        }
-      ]
+      "rate": 0.19
+    }]
+  },
+  "customerGroup": {
+    "typeId": "customer-group",
+    "id": "customer-group-2",
+    "obj": {
+      "name": "cool customers"
+    }
+  },
+  "shippingAddress": {
+    "firstName": "Jane",
+    "lastName": "Doe",
+    "streetName": "Some Other Street ",
+    "streetNumber": "22",
+    "postalCode": "22222",
+    "city": "Some Other City",
+    "country": "US"
+  },
+  "billingAddress": {
+    "firstName": "Jane",
+    "lastName": "Doe",
+    "streetName": "Some Other Street ",
+    "streetNumber": "22",
+    "postalCode": "22222",
+    "city": "Some Other City",
+    "country": "US"
+  },
+  "shippingInfo": {
+    "price": {
+      "centAmount": 499,
+      "currencyCode": "USD"
     },
-    "customerGroup": {
-      "typeId": "customer-group",
-      "id": "customer-group-2",
-      "obj": {
-        "name": "cool customers"
-      }
-    },
-    "shippingAddress": {
-      "firstName": "Jane",
-      "lastName": "Doe",
-      "streetName": "Some Other Street ",
-      "streetNumber": "22",
-      "postalCode": "22222",
-      "city": "Some Other City",
-      "country": "US"
-    },
-    "billingAddress": {
-      "firstName": "Jane",
-      "lastName": "Doe",
-      "streetName": "Some Other Street ",
-      "streetNumber": "22",
-      "postalCode": "22222",
-      "city": "Some Other City",
-      "country": "US"
-    },
-    "shippingInfo": {
+    "shippingRate": {
       "price": {
         "centAmount": 499,
         "currencyCode": "USD"
       },
-      "shippingRate": {
-        "price": {
-          "centAmount": 499,
-          "currencyCode": "USD"
-        },
-        "freeAbove": {
-          "centAmount": 20000,
-          "currencyCode": "USD"
-        }
-      },
-      "taxRate": {
-        "name": "Standard Tax Rate",
-        "amount": 0.19,
-        "includedInPrice": true,
-        "id": "taxRateId",
-        "country": "US"
-      },
-      "taxCategory": {
-        "typeId": "tax-category",
-        "id": "taxCategoryId"
-      },
-      "deliveries": [
-        {
-          "id": "deliveryId-2-1",
-          "createdAt": "1970-01-01T00:00:00.006Z",
-          "items": [
-            {
-              "id": "LineItemId-2-1",
-              "quantity": 1
-            }
-          ]
-        }
-      ]
+      "freeAbove": {
+        "centAmount": 20000,
+        "currencyCode": "USD"
+      }
     },
-    "discountCodes": [
-      {
-        "discountCode": {
-          "typeId": "discount-code",
-          "obj": {
-            "code": "code3"
-          }
-        },
-        "state": "MatchesCart"
-      }
-    ],
-    "paymentInfo": {
-      "payments": [{ "typeId": "payment", "id": "payment3" }]
-    }
+    "taxRate": {
+      "name": "Standard Tax Rate",
+      "amount": 0.19,
+      "includedInPrice": true,
+      "id": "taxRateId",
+      "country": "US"
+    },
+    "taxCategory": {
+      "typeId": "tax-category",
+      "id": "taxCategoryId"
+    },
+    "deliveries": [{
+      "id": "deliveryId-2-1",
+      "createdAt": "1970-01-01T00:00:00.006Z",
+      "items": [{
+        "id": "LineItemId-2-1",
+        "quantity": 1
+      }]
+    }]
   },
-  {
-    "id": "ijk",
-    "orderNumber": "10003",
-    "createdAt": "1970-01-01T00:00:00.004Z",
-    "lastModifiedAt": "1970-01-01T00:00:00.005Z",
-    "version": 1,
-    "lineItems": [
-      {
-        "id": "LineItemId-3-1",
-        "productId": "ProductId-3-1",
-        "name": {
-          "en": "Product-3-1"
-        },
-        "variant": {
-          "variantId": 1,
-          "sku": "SKU-3-1",
-          "images": [
-            {
-              "url": "http://www.example.org/image-3-1-1.jpg",
-              "dimensions": {
-                "w": 0,
-                "h": 0
-              }
-            }
-          ],
-          "attributes": []
-        },
-        "quantity": 1,
-        "price": {
-          "country": "DE",
-          "value": {
-            "currencyCode": "EUR",
-            "centAmount": 3000
-          }
-        },
-        "state": [
-          {
-            "quantity": 1,
-            "state": {
-              "typeId": "state",
-              "id": "state-1",
-              "obj": {
-                "key": "firstState"
-              }
-            }
-          }
-        ],
-        "taxRate": {
-          "name": "Standard Tax Rate",
-          "amount": 0.25,
-          "includedInPrice": true,
-          "id": "taxRateId",
-          "country": "DE"
-        },
-        "supplyChannel": {
-          "typeId": "channel",
-          "id": "channel-3",
-          "obj": {
-            "key": "thirdChannel"
-          }
+  "discountCodes": [{
+    "discountCode": {
+      "typeId": "discount-code",
+        "obj": {
+        "code": "code3"
+      }
+    },
+    "state": "MatchesCart"
+  }],
+  "paymentInfo": {
+    "payments": [
+    { "typeId": "payment", "id": "payment3" }
+    ]
+  }
+}, {
+  "id": "ijk",
+  "orderNumber": "10003",
+  "createdAt": "1970-01-01T00:00:00.004Z",
+  "lastModifiedAt": "1970-01-01T00:00:00.005Z",
+  "version": 1,
+  "lineItems": [{
+    "id": "LineItemId-3-1",
+    "productId": "ProductId-3-1",
+    "name": {
+      "en": "Product-3-1"
+    },
+    "variant": {
+      "variantId": 1,
+      "sku": "SKU-3-1",
+      "images": [{
+        "url": "http://www.example.org/image-3-1-1.jpg",
+        "dimensions": {
+          "w": 0,
+          "h": 0
+        }
+      }],
+      "attributes": []
+    },
+    "quantity": 1,
+    "price": {
+      "country": "DE",
+      "value": {
+        "currencyCode": "EUR",
+        "centAmount": 3000
+      }
+    },
+    "state": [{
+      "quantity": 1,
+      "state": {
+        "typeId": "state",
+        "id": "state-1",
+        "obj": {
+          "key": "firstState"
         }
       }
-    ],
-    "customLineItems": [],
-    "totalPrice": {
+    }],
+    "taxRate": {
+      "name": "Standard Tax Rate",
+      "amount": 0.25,
+      "includedInPrice": true,
+      "id": "taxRateId",
+      "country": "DE"
+    },
+    "supplyChannel": {
+      "typeId": "channel",
+      "id": "channel-3",
+      "obj": {
+        "key": "thirdChannel"
+      }
+    }
+  }],
+  "customLineItems": [],
+  "totalPrice": {
+    "currencyCode": "EUR",
+    "centAmount": 3000
+  },
+  "taxedPrice": {
+    "totalNet": {
+      "currencyCode": "EUR",
+      "centAmount": 2250
+    },
+    "totalGross": {
       "currencyCode": "EUR",
       "centAmount": 3000
     },
-    "taxedPrice": {
-      "totalNet": {
+    "taxPortions": [{
+      "amount": {
         "currencyCode": "EUR",
-        "centAmount": 2250
+        "centAmount": 750
       },
-      "totalGross": {
-        "currencyCode": "EUR",
-        "centAmount": 3000
-      },
-      "taxPortions": [
-        {
-          "amount": {
-            "currencyCode": "EUR",
-            "centAmount": 750
-          },
-          "rate": 0.25
-        }
-      ]
+      "rate": 0.25
+    }]
+  },
+  "customerGroup": {
+    "typeId": "customer-group",
+    "id": "customer-group-3",
+    "obj": {
+      "name": "tech customers"
+    }
+  },
+  "shippingAddress": {
+    "firstName": "John",
+    "lastName": "Bull",
+    "streetName": "One Way Street",
+    "streetNumber": "3",
+    "postalCode": "3333",
+    "city": "Star City",
+    "country": "DE"
+  },
+  "billingAddress": {
+    "firstName": "John",
+    "lastName": "Bull",
+    "streetName": "One Way Street",
+    "streetNumber": "3",
+    "postalCode": "3333",
+    "city": "Star City",
+    "country": "DE"
+  },
+  "shippingInfo": {
+    "price": {
+      "centAmount": 500,
+      "currencyCode": "EUR"
     },
-    "customerGroup": {
-      "typeId": "customer-group",
-      "id": "customer-group-3",
-      "obj": {
-        "name": "tech customers"
-      }
-    },
-    "shippingAddress": {
-      "firstName": "John",
-      "lastName": "Bull",
-      "streetName": "One Way Street",
-      "streetNumber": "3",
-      "postalCode": "3333",
-      "city": "Star City",
-      "country": "DE"
-    },
-    "billingAddress": {
-      "firstName": "John",
-      "lastName": "Bull",
-      "streetName": "One Way Street",
-      "streetNumber": "3",
-      "postalCode": "3333",
-      "city": "Star City",
-      "country": "DE"
-    },
-    "shippingInfo": {
+    "shippingRate": {
       "price": {
         "centAmount": 500,
         "currencyCode": "EUR"
       },
-      "shippingRate": {
-        "price": {
-          "centAmount": 500,
-          "currencyCode": "EUR"
-        },
-        "freeAbove": {
-          "centAmount": 20000,
-          "currencyCode": "EUR"
-        }
-      },
-      "taxRate": {
-        "name": "Standard Tax Rate",
-        "amount": 0.25,
-        "includedInPrice": true,
-        "id": "taxRateId",
-        "country": "DE"
-      },
-      "taxCategory": {
-        "typeId": "tax-category",
-        "id": "taxCategoryId"
-      },
-      "deliveries": [
-        {
-          "id": "deliveryId-3-1",
-          "createdAt": "1970-01-01T00:00:00.006Z",
-          "items": [
-            {
-              "id": "LineItemId-3-1",
-              "quantity": 1
-            }
-          ]
-        }
-      ]
-    },
-    "discountCodes": [
-      {
-        "discountCode": {
-          "typeId": "discount-code"
-        },
-        "state": "MatchesCart"
+      "freeAbove": {
+        "centAmount": 20000,
+        "currencyCode": "EUR"
       }
-    ],
-    "paymentInfo": {
-      "payments": [{ "typeId": "payment", "id": "payment4" }]
-    }
+    },
+    "taxRate": {
+      "name": "Standard Tax Rate",
+      "amount": 0.25,
+      "includedInPrice": true,
+      "id": "taxRateId",
+      "country": "DE"
+    },
+    "taxCategory": {
+      "typeId": "tax-category",
+      "id": "taxCategoryId"
+    },
+    "deliveries": [{
+      "id": "deliveryId-3-1",
+      "createdAt": "1970-01-01T00:00:00.006Z",
+      "items": [{
+        "id": "LineItemId-3-1",
+        "quantity": 1
+      }]
+    }]
+  },
+  "discountCodes": [{
+    "discountCode": {
+      "typeId": "discount-code"
+    },
+    "state": "MatchesCart"
+  }],
+  "paymentInfo": {
+    "payments": [
+    { "typeId": "payment", "id": "payment4" }
+    ]
   }
-]
+}]

--- a/data/orders.json
+++ b/data/orders.json
@@ -699,8 +699,7 @@
     "discountCodes": [
       {
         "discountCode": {
-          "typeId": "discount-code",
-          "obj": {}
+          "typeId": "discount-code"
         },
         "state": "MatchesCart"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sphere-order-export",
-  "version": "2.2.0",
+  "version": "2.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -142,6 +142,7 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
+      "optional": true,
       "requires": {
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
@@ -1550,7 +1551,7 @@
     },
     "eventemitter2": {
       "version": "0.4.14",
-      "resolved": "http://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
+      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
       "integrity": "sha1-j2G3XN4BKy6esoTUVFWDtWQ7Yas=",
       "dev": true
     },
@@ -2358,7 +2359,7 @@
       "dependencies": {
         "rimraf": {
           "version": "2.2.8",
-          "resolved": "http://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
           "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
           "dev": true
         }
@@ -2566,7 +2567,7 @@
         },
         "chalk": {
           "version": "0.3.0",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-0.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.3.0.tgz",
           "integrity": "sha1-HJhDdzfxGZ68wdTEj9Qbn5yOjyM=",
           "dev": true,
           "requires": {
@@ -3231,7 +3232,7 @@
         },
         "mkdirp": {
           "version": "0.3.5",
-          "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
           "integrity": "sha1-3j5fiWHIjHh+4TaN+EmsRBPsqNc=",
           "dev": true
         },
@@ -3254,7 +3255,7 @@
       "dependencies": {
         "mkdirp": {
           "version": "0.3.5",
-          "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
           "integrity": "sha1-3j5fiWHIjHh+4TaN+EmsRBPsqNc=",
           "dev": true
         }
@@ -3851,7 +3852,7 @@
     },
     "minimist": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
     "mixin-deep": {
@@ -3875,7 +3876,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
@@ -3883,7 +3884,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         }
       }
@@ -4237,7 +4238,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.10",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
           "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
         }
       }

--- a/src/coffee/mapping-utils/csv.coffee
+++ b/src/coffee/mapping-utils/csv.coffee
@@ -102,7 +102,8 @@ class CsvMapping
     return _.map(payments.payments, ({ id }) -> id).join(';')
 
   formatDiscountCodes = (discountCodes) ->
-    return _.map(discountCodes, ({ discountCode: { obj: { code } } }) -> code).join(';')
+    return _.map(discountCodes, ({ discountCode}) ->
+      if discountCode.obj then discountCode.obj.code else '').join(';')
   # TODO: Move method below to sphere-node-utils
 
   formatProductAttributes: (attributeName, attributes) ->

--- a/src/spec/mapping-utils/csv.spec.coffee
+++ b/src/spec/mapping-utils/csv.spec.coffee
@@ -21,6 +21,7 @@ describe 'Mapping utils - CSV', ->
         id,orderNumber
         abc,10001
         xyz,10002
+        ijk,10003
         """
 
       @csvMapping.mapOrders(template, ordersJson)
@@ -51,6 +52,7 @@ describe 'Mapping utils - CSV', ->
         #{fields.join(',')}
         abc,10001,USD 5950,USD 5000,USD 5950,USD 5000,USD 5950,USD 499,USD 0,USD 495,USD 20000,0
         xyz,10002,USD 2380,USD 2000,USD 2380,USD 2000,USD 2380,USD 499,,,USD 20000,
+        ijk,10003,EUR 3000,EUR 2250,EUR 3000,EUR 2250,EUR 3000,EUR 500,,,EUR 20000,
         """
 
       @csvMapping.mapOrders(template, ordersJson)
@@ -69,6 +71,7 @@ describe 'Mapping utils - CSV', ->
         id,orderNumber,totalPrice,totalNet,totalGross,discountCodes
         abc,10001,USD 5950,USD 5000,USD 5950,code1;code2
         xyz,10002,USD 2380,USD 2000,USD 2380,code3
+        ijk,10003,EUR 3000,EUR 2250,EUR 3000,
         """
 
       @csvMapping.mapOrders(template, ordersJson)
@@ -87,6 +90,7 @@ describe 'Mapping utils - CSV', ->
         id,orderNumber,totalPrice,totalNet,totalGross,paymentInfo
         abc,10001,USD 5950,USD 5000,USD 5950,payment1;payment2
         xyz,10002,USD 2380,USD 2000,USD 2380,payment3
+        ijk,10003,EUR 3000,EUR 2250,EUR 3000,payment4
         """
 
       @csvMapping.mapOrders(template, ordersJson)
@@ -106,6 +110,7 @@ describe 'Mapping utils - CSV', ->
         id,orderNumber,billingAddress.firstName,billingAddress.lastName,billingAddress.streetName,billingAddress.streetNumber,billingAddress.postalCode,billingAddress.city,billingAddress.country,shippingAddress.firstName,shippingAddress.lastName,shippingAddress.streetName,shippingAddress.streetNumber,shippingAddress.postalCode,shippingAddress.city,shippingAddress.country
         abc,10001,John,Doe,Some Street,11,11111,Some City,US,John,Doe,Some Street,11,11111,Some City,US
         xyz,10002,Jane,Doe,Some Other Street ,22,22222,Some Other City,US,Jane,Doe,Some Other Street ,22,22222,Some Other City,US
+        ijk,10003,John,Bull,One Way Street,3,3333,Star City,DE,John,Bull,One Way Street,3,3333,Star City,DE
         """
 
       @csvMapping.mapOrders(template, ordersJson)
@@ -128,6 +133,8 @@ describe 'Mapping utils - CSV', ->
         abc,10001,LineItemId-1-2,ProductId-1-2,Product-1-2,2,SKU-1-2,3,US-USD 1190
         xyz,10002,,,,,,,
         xyz,10002,LineItemId-2-1,ProductId-2-1,Product-2-1,1,SKU-2-1,1,US-USD 2380
+        ijk,10003,,,,,,,
+        ijk,10003,LineItemId-3-1,ProductId-3-1,Product-3-1,1,SKU-3-1,1,DE-EUR 3000
         """
 
       @csvMapping.mapOrders(template, ordersJson)
@@ -150,6 +157,8 @@ describe 'Mapping utils - CSV', ->
         abc,10001,LineItemId-1-2,ProductId-1-2,Product-1-2,2,SKU-1-2,3,US-USD 1190,,,
         xyz,10002,,,,,,,,USD 2380,USD 2000,USD 2380
         xyz,10002,LineItemId-2-1,ProductId-2-1,Product-2-1,1,SKU-2-1,1,US-USD 2380,,,
+        ijk,10003,,,,,,,,EUR 3000,EUR 2250,EUR 3000
+        ijk,10003,LineItemId-3-1,ProductId-3-1,Product-3-1,1,SKU-3-1,1,DE-EUR 3000,,,
         """
 
       @csvMapping.mapOrders(template, ordersJson)
@@ -199,6 +208,8 @@ describe 'Mapping utils - CSV', ->
         abc,10001,LineItemId-1-2,thirdState:1;secondState:1;firstState:1;
         xyz,10002,,
         xyz,10002,LineItemId-2-1,firstState:1;
+        ijk,10003,,
+        ijk,10003,LineItemId-3-1,firstState:1;
         """
 
       @csvMapping.mapOrders(template, ordersJson)
@@ -221,6 +232,8 @@ describe 'Mapping utils - CSV', ->
         abc,10001,LineItemId-1-2,http://www.example.org/image-2-1-1.jpg;http://www.example.org/image-2-1-2.jpg;http://www.example.org/image-2-1-3.jpg
         xyz,10002,,
         xyz,10002,LineItemId-2-1,http://www.example.org/image-2-1-1.jpg
+        ijk,10003,,
+        ijk,10003,LineItemId-3-1,http://www.example.org/image-3-1-1.jpg
         """
 
       @csvMapping.mapOrders(template, ordersJson)
@@ -243,6 +256,8 @@ describe 'Mapping utils - CSV', ->
         abc,10001,LineItemId-1-2,secondChannel
         xyz,10002,,
         xyz,10002,LineItemId-2-1,secondChannel
+        ijk,10003,,
+        ijk,10003,LineItemId-3-1,thirdChannel
         """
 
       @csvMapping.mapOrders(template, ordersJson)
@@ -262,6 +277,7 @@ describe 'Mapping utils - CSV', ->
         id,orderNumber,customerGroup
         abc,10001,
         xyz,10002,cool customers
+        ijk,10003,tech customers
         """
 
       @csvMapping.mapOrders(template, ordersJson)


### PR DESCRIPTION
#### Summary
Deleted discount codes
#### Description
This PR fixes the order export crashes caused by deleted `discount code` that has been used on a completed order.

#### Todo

- Tests
    - [x] Unit
    - [x] Integration

Closes #80 
