### PR TITLE
chore: Drop support for Node < 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
-  - 6
-  - 8
+  - 10
+  - 12
 branches:
   except:
     - latest

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "main": "lib/run",
   "engines": {
-    "node": ">= 6.0.0"
+    "node": ">= 10.0.0"
   },
   "scripts": {
     "test": "grunt coverage",


### PR DESCRIPTION
#### Drop Support for node less than version 10
1) Updated Node JS version on package.json
2) Updated Test cases node JS version

Closes #95 